### PR TITLE
Adjust nexus url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
     <distributionManagement>
         <snapshotRepository>
             <id>nexus.gadevs</id>
-            <url>https://nexus.gadevs.ga./repository/maven-snapshots/</url>
+            <url>https://nexus.gadevs.ga/repository/maven-snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 </project>


### PR DESCRIPTION
The SSL certificate is for nexus.gadevs.ga (without the trailing dot).